### PR TITLE
"text" values should be skipped when signing

### DIFF
--- a/StarBank/Bank Stuffs/BankSignatureGenerator.cs
+++ b/StarBank/Bank Stuffs/BankSignatureGenerator.cs
@@ -27,7 +27,7 @@ namespace StarBank.Bank_Stuffs
                     inputString.Append(key.Name);
                     inputString.Append("Value");
                     inputString.Append(key.Type);
-                    inputString.Append(key.Value);
+                    if(key.Type != "text") inputString.Append(key.Value);
                 }
             }
 


### PR DESCRIPTION
See how this other repo does it: https://github.com/Talv/sc2-repdump/blob/e31dede06512d7b3e445b96327102defe28083a2/s2repdump/bank.py#L92

After changing this, I'm able to sign bank files with signatures that match the game.